### PR TITLE
Extract logging capabilities into goggin-rs-logger library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Rust
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Lint
+        run: cargo clippy --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test --all-features
+
+      - name: Check WASM
+        run: cargo check --target wasm32-unknown-unknown --features leptos
+
+      - name: Build docs
+        run: cargo doc --no-deps --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/target
+/target/
+Cargo.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,6 @@ When working with git you should follow these conventions:
 - NEVER commit or push to `main`
 - If asked to push to `main` prompt me about creating a branch
 - NEVER create a new branch without my permission
+- NEVER commit without my permission
+- NEVER push with my permission
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Project Goal
 
-The goal of this project is to migrate the existing logging system from used in
-[GigLog](https://github.com/joegoggin/gig-log) into it's own library. Use the
-existing implementation as much as possible. 
+The goal of this project is to migrate the existing logging system used in
+[GigLog](https://github.com/joegoggin/gig-log) into its own library. Use the
+existing implementation as much as possible.
 
 ## GitHub Project
 
@@ -18,5 +18,4 @@ When working with git you should follow these conventions:
 - If asked to push to `main` prompt me about creating a branch
 - NEVER create a new branch without my permission
 - NEVER commit without my permission
-- NEVER push with my permission
-
+- NEVER push without my permission

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "goggin-rs-logger"
 version = "0.1.0"
 edition = "2024"
+description = "Logging utilities extracted from GigLog for native Rust, Axum, and Leptos/WASM applications."
+license = "MIT"
+readme = "README.md"
 repository = "https://github.com/joegoggin/goggin-rs-logger"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 uuid = { version = "1.21.0", features = ["v4"], optional = true }
 wasm-bindgen-futures = { version = "0.4.64", optional = true }
+
+[dev-dependencies]
+tokio = { version = "1.48.0", features = ["macros", "rt"] }
+tower = { version = "0.5.2", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,20 @@
 name = "goggin-rs-logger"
 version = "0.1.0"
 edition = "2024"
+repository = "https://github.com/joegoggin/goggin-rs-logger"
+
+[features]
+default = []
+axum = ["dep:axum", "dep:uuid"]
+leptos = ["dep:gloo-net", "dep:wasm-bindgen-futures"]
 
 [dependencies]
+axum = { version = "0.8.8", optional = true }
+colorized = "1.0.0"
+dotenvy = "0.15.7"
+gloo-net = { version = "0.6.0", optional = true }
+log = "0.4.28"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+uuid = { version = "1.21.0", features = ["v4"], optional = true }
+wasm-bindgen-futures = { version = "0.4.64", optional = true }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Joe Goggin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# goggin-rs-logger
+
+Rust logging utilities extracted from GigLog.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ goggin-rs-logger = { git = "https://github.com/joegoggin/goggin-rs-logger", feat
 ## Native logger
 
 ```rust
-use goggin_rs_logger::{Logger, log_message, log_success};
+use goggin_rs_logger::{Logger, info, log_message, log_success};
 
 fn main() {
     Logger::setup_logging("info", false);
 
     log_message("hello from goggin-rs-logger");
-    log::info!("standard log facade message");
+    info!("standard log facade message");
     log_success("startup complete");
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,141 @@
 # goggin-rs-logger
 
-Rust logging utilities extracted from GigLog.
+`goggin-rs-logger` is a Rust logging helper crate built on the `log` facade.
+It provides a colorized global logger, semantic status helpers, optional Axum
+request/response middleware, and an optional browser-to-server relay for
+Leptos/WASM applications.
+
+## Install
+
+Default native logger:
+
+```toml
+[dependencies]
+goggin-rs-logger = { git = "https://github.com/joegoggin/goggin-rs-logger" }
+```
+
+With Axum request/response middleware and relay receiver:
+
+```toml
+[dependencies]
+goggin-rs-logger = { git = "https://github.com/joegoggin/goggin-rs-logger", features = ["axum"] }
+```
+
+With Leptos/WASM browser relay emitter:
+
+```toml
+[dependencies]
+goggin-rs-logger = { git = "https://github.com/joegoggin/goggin-rs-logger", features = ["leptos"] }
+```
+
+With both relay emitter and receiver APIs:
+
+```toml
+[dependencies]
+goggin-rs-logger = { git = "https://github.com/joegoggin/goggin-rs-logger", features = ["axum", "leptos"] }
+```
+
+## Native logger
+
+```rust
+use goggin_rs_logger::{Logger, log_message, log_success};
+
+fn main() {
+    Logger::setup_logging("info", false);
+
+    log_message("hello from goggin-rs-logger");
+    log::info!("standard log facade message");
+    log_success("startup complete");
+}
+```
+
+Use `Logger::setup_logging_from_env()` to read `LOG_LEVEL` and `LOG_VERBOSE`
+from the environment. `LOG_LEVEL` defaults to `info`; `LOG_VERBOSE` defaults to
+verbose output.
+
+## Axum middleware
+
+Enable the `axum` feature to log HTTP requests and responses.
+
+```rust
+use axum::{Router, middleware, routing::get};
+use goggin_rs_logger::{HttpLoggingConfig, Logger};
+
+fn app() -> Router {
+    Router::new()
+        .route("/", get(|| async { "ok" }))
+        .route_layer(middleware::from_fn_with_state(
+            HttpLoggingConfig::default(),
+            Logger::log_request_and_response,
+        ))
+}
+```
+
+`HttpLoggingConfig::default()` disables body logging, uses a 16 KB body limit,
+and emits verbose output. Use `HttpLoggingConfig::new(body_enabled,
+max_body_bytes, verbose)` to override those settings.
+
+## Leptos/WASM browser emitter
+
+Enable the `leptos` feature to relay browser logs through the `log` facade.
+
+```rust
+use goggin_rs_logger::{
+    WebLoggerConfig, init_web_logging, init_web_logging_with_config,
+};
+
+pub fn install_browser_logger() -> Result<(), log::SetLoggerError> {
+    init_web_logging("info")?;
+    Ok(())
+}
+
+pub fn install_browser_logger_with_custom_endpoint() -> Result<(), log::SetLoggerError> {
+    let config = WebLoggerConfig::new("debug").with_endpoint("/internal/web-log");
+    init_web_logging_with_config(config)?;
+    Ok(())
+}
+```
+
+`WEB_LOG_LEVEL` takes precedence over the default level passed to
+`init_web_logging` or `WebLoggerConfig::new`.
+
+## Axum relay receiver
+
+Enable the `axum` feature to receive browser relay payloads on the server.
+
+```rust
+use std::sync::Arc;
+
+use axum::Router;
+use goggin_rs_logger::{RelayLogSink, RelayReceiverState, relay_router};
+
+fn app() -> Router {
+    let sink: RelayLogSink = Arc::new(|line| println!("{line}"));
+    let relay_state = RelayReceiverState::new(sink, false);
+
+    Router::new().merge(relay_router(relay_state))
+}
+```
+
+The default browser endpoint is `/_leptos/web-log`. `relay_router` accepts
+`POST /_leptos/web-log` for that default path and `POST /` so applications can
+mount the receiver router under a custom endpoint that matches
+`WebLoggerConfig::with_endpoint`.
+
+## Relay contract
+
+Browser emitters post `RelayLogPayload` JSON:
+
+```json
+{
+  "level": "info",
+  "message": "settings saved",
+  "target": "app::settings",
+  "file": "src/settings.rs",
+  "line": 42
+}
+```
+
+`level` and `message` are required. `target`, `file`, and `line` are optional.
+The server receiver formats each payload with the same native logger style and
+passes every formatted line to the configured `RelayLogSink`.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,202 @@
+//! Application-wide log backend.
+//!
+//! Implements the [`log::Log`] trait with colorized, optionally verbose output
+//! for `goggin-rs-logger`. In verbose mode, errors and debug messages include
+//! the source file and line number; in compact mode, only the level tag and
+//! message are printed.
+
+use std::{
+    env,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use colorized::{Colors, colorize_println};
+use log::{Level, Log, Metadata, Record, set_logger, set_max_level};
+
+use crate::{
+    formatting::{extract_after_src, get_hashtags, log_debug, log_error},
+    parse_level_filter,
+};
+
+/// Log target for semantic informational messages.
+pub(crate) const MESSAGE_TARGET: &str = "goggin_rs_logger::message";
+/// Log target for semantic success messages.
+pub(crate) const SUCCESS_TARGET: &str = "goggin_rs_logger::success";
+
+/// Application-wide logger that implements [`log::Log`].
+///
+/// Provides both a verbose mode (structured output with file paths and line
+/// numbers) and a compact mode (level-tagged single lines). Also exposes
+/// helper methods for printing colored status banners during startup.
+pub struct Logger;
+
+/// Stores the global logger instance registered with [`log`].
+static LOGGER: Logger = Logger;
+/// Stores whether verbose log formatting is enabled.
+static LOG_VERBOSE: AtomicBool = AtomicBool::new(true);
+
+impl Logger {
+    /// Registers the global logger and sets the maximum log level.
+    ///
+    /// # Arguments
+    ///
+    /// * `log_level` - A string parsed into a [`LevelFilter`](log::LevelFilter)
+    ///   (for example, `"debug"` or `"info"`).
+    /// * `verbose` - When `true`, log output includes source locations and
+    ///   decorative banners; when `false`, uses compact single-line format.
+    pub fn setup_logging(log_level: &str, verbose: bool) {
+        LOG_VERBOSE.store(verbose, Ordering::Relaxed);
+
+        let _ = set_logger(&LOGGER);
+        set_max_level(parse_level_filter(log_level));
+    }
+
+    /// Bootstraps logging from `LOG_LEVEL` and `LOG_VERBOSE` environment variables.
+    ///
+    /// Intended for early startup before application configuration is available.
+    /// Defaults to `"info"` level with verbose output.
+    pub fn setup_logging_from_env() {
+        dotenvy::dotenv().ok();
+
+        let level = env::var("LOG_LEVEL").unwrap_or_else(|_| "info".to_string());
+        let verbose = env::var("LOG_VERBOSE")
+            .ok()
+            .map(|value| match value.trim().to_ascii_lowercase().as_str() {
+                "true" | "1" | "yes" | "on" => true,
+                "false" | "0" | "no" | "off" => false,
+                _ => true,
+            })
+            .unwrap_or(true);
+
+        Self::setup_logging(&level, verbose);
+    }
+
+    /// Returns `true` when verbose logging is enabled.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the logger was initialized with `verbose` set to `true`.
+    pub fn is_verbose() -> bool {
+        LOG_VERBOSE.load(Ordering::Relaxed)
+    }
+
+    /// Prints a green success banner (verbose) or a plain green line (compact).
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The text to display.
+    pub fn log_success(message: &str) {
+        if !log::log_enabled!(Level::Info) {
+            return;
+        }
+
+        if Self::is_verbose() {
+            let hashtags = get_hashtags(6);
+            let message = format!("\n{} {} {}\n", hashtags, message, hashtags);
+            colorize_println(message, Colors::GreenFg);
+            return;
+        }
+
+        colorize_println(message, Colors::GreenFg);
+    }
+
+    /// Prints a blue informational banner (verbose) or a plain blue line (compact).
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The text to display.
+    pub fn log_message(message: &str) {
+        if !log::log_enabled!(Level::Info) {
+            return;
+        }
+
+        if Self::is_verbose() {
+            let hashtags = get_hashtags(6);
+            let message = format!("\n{} {} {}\n", hashtags, message, hashtags);
+            colorize_println(message, Colors::BlueFg);
+            return;
+        }
+
+        colorize_println(message, Colors::BlueFg);
+    }
+}
+
+impl Log for Logger {
+    fn enabled(&self, _: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let file_path = extract_after_src(record.file());
+
+        if file_path.contains("index.crates") {
+            return;
+        }
+
+        if !Logger::is_verbose() {
+            match record.level() {
+                Level::Error => {
+                    colorize_println(format!("[ERROR] {}", record.args()), Colors::RedFg)
+                }
+                Level::Warn => {
+                    colorize_println(format!("[WARN] {}", record.args()), Colors::YellowFg)
+                }
+                Level::Info => match record.target() {
+                    SUCCESS_TARGET => colorize_println(record.args().to_string(), Colors::GreenFg),
+                    MESSAGE_TARGET => colorize_println(record.args().to_string(), Colors::BlueFg),
+                    _ => println!("{}", record.args()),
+                },
+                Level::Debug => {
+                    colorize_println(format!("[DEBUG] {}", record.args()), Colors::BlueFg)
+                }
+                Level::Trace => {
+                    colorize_println(format!("[TRACE] {}", record.args()), Colors::MagentaFg)
+                }
+            }
+
+            return;
+        }
+
+        let blue = "\x1b[34m";
+        let purple = "\x1b[35m";
+        let clear = "\x1b[0m";
+        let line_number = record
+            .line()
+            .map(|line| line.to_string())
+            .unwrap_or_default();
+
+        match record.level() {
+            Level::Info => match record.target() {
+                SUCCESS_TARGET => {
+                    let hashtags = get_hashtags(6);
+                    let message = format!("\n{} {} {}\n", hashtags, record.args(), hashtags);
+                    colorize_println(message, Colors::GreenFg);
+                }
+                MESSAGE_TARGET => {
+                    let hashtags = get_hashtags(6);
+                    let message = format!("\n{} {} {}\n", hashtags, record.args(), hashtags);
+                    colorize_println(message, Colors::BlueFg);
+                }
+                _ => println!("\n{}{}{}", blue, record.args(), clear),
+            },
+            Level::Error => log_error(record),
+            Level::Debug => log_debug(record),
+            _ => println!(
+                "\n{}File: {}{}\n{}Line Number: {}{}\n{}",
+                purple,
+                file_path,
+                clear,
+                purple,
+                line_number,
+                clear,
+                record.args(),
+            ),
+        }
+    }
+
+    fn flush(&self) {}
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -44,6 +44,10 @@ impl Logger {
     ///   (for example, `"debug"` or `"info"`).
     /// * `verbose` - When `true`, log output includes source locations and
     ///   decorative banners; when `false`, uses compact single-line format.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
     pub fn setup_logging(log_level: &str, verbose: bool) {
         LOG_VERBOSE.store(verbose, Ordering::Relaxed);
 
@@ -55,6 +59,10 @@ impl Logger {
     ///
     /// Intended for early startup before application configuration is available.
     /// Defaults to `"info"` level with verbose output.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
     pub fn setup_logging_from_env() {
         dotenvy::dotenv().ok();
 
@@ -85,6 +93,10 @@ impl Logger {
     /// # Arguments
     ///
     /// * `message` - The text to display.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
     pub fn log_success(message: &str) {
         if !log::log_enabled!(Level::Info) {
             return;
@@ -105,6 +117,10 @@ impl Logger {
     /// # Arguments
     ///
     /// * `message` - The text to display.
+    ///
+    /// # Returns
+    ///
+    /// This function does not return a value.
     pub fn log_message(message: &str) {
         if !log::log_enabled!(Level::Info) {
             return;

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -1,0 +1,471 @@
+//! Log output formatting for general log records and optional HTTP traffic.
+//!
+//! Provides colorized, structured output helpers used by the [`Logger`](crate::Logger)
+//! backend. When the `axum` feature is enabled, this module also includes
+//! request/response formatting helpers for future HTTP middleware support.
+
+#[cfg(feature = "axum")]
+use axum::http::{HeaderMap, Method, StatusCode};
+#[cfg(feature = "axum")]
+use colorized::colorize_print;
+use colorized::{Colors, colorize_println};
+use log::Record;
+#[cfg(feature = "axum")]
+use serde_json::Value;
+#[cfg(feature = "axum")]
+use uuid::Uuid;
+
+#[cfg(feature = "axum")]
+use crate::redaction::sanitize_header_value;
+
+/// Broad classification of an HTTP status code for color selection.
+#[cfg(feature = "axum")]
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StatusClass {
+    /// Indicates a 2xx successful response.
+    Success,
+    /// Indicates a 4xx client error response.
+    ClientError,
+    /// Indicates a 5xx server error response.
+    ServerError,
+    /// Indicates any non-2xx/4xx/5xx response class.
+    Other,
+}
+
+/// Maps an HTTP status code to its [`StatusClass`].
+///
+/// # Arguments
+///
+/// * `status_code` - The HTTP status code to classify.
+///
+/// # Returns
+///
+/// The corresponding [`StatusClass`] variant.
+#[cfg(feature = "axum")]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) fn classify_status(status_code: StatusCode) -> StatusClass {
+    if status_code.is_success() {
+        StatusClass::Success
+    } else if status_code.is_client_error() {
+        StatusClass::ClientError
+    } else if status_code.is_server_error() {
+        StatusClass::ServerError
+    } else {
+        StatusClass::Other
+    }
+}
+
+/// Returns a string of `#` characters with the given length, used for banner headings.
+///
+/// # Arguments
+///
+/// * `level` - The number of `#` characters to produce.
+///
+/// # Returns
+///
+/// A [`String`] containing `level` hash characters.
+pub(super) fn get_hashtags(level: i8) -> String {
+    let mut hashtags = String::new();
+
+    for _ in 0..level {
+        hashtags.push('#');
+    }
+
+    hashtags
+}
+
+/// Returns an indentation string of `level * 2` spaces, used for nested JSON output.
+///
+/// # Arguments
+///
+/// * `level` - The nesting depth; each level adds two spaces.
+///
+/// # Returns
+///
+/// A [`String`] containing `level * 2` space characters.
+#[cfg(any(feature = "axum", test))]
+pub(super) fn get_spaces(level: i8) -> String {
+    let mut spaces = String::new();
+
+    for _ in 0..level {
+        spaces.push_str("  ");
+    }
+
+    spaces
+}
+
+/// Prints a colored heading surrounded by the given hashtag string.
+///
+/// # Arguments
+///
+/// * `header` - The heading text.
+/// * `hashtags` - The `#` string placed on each side of the heading.
+#[cfg(feature = "axum")]
+#[allow(dead_code)]
+fn log_header(header: &str, hashtags: &str) {
+    let header_string = format!("\n{} {} {}\n", hashtags, header, hashtags);
+    colorize_println(header_string, Colors::MagentaFg);
+}
+
+/// Prints a level-1 heading (6 `#` characters).
+///
+/// # Arguments
+///
+/// * `header` - The heading text.
+#[cfg(feature = "axum")]
+#[allow(dead_code)]
+fn log_h1(header: &str) {
+    log_header(header, &get_hashtags(6));
+}
+
+/// Prints a level-2 heading (5 `#` characters).
+///
+/// # Arguments
+///
+/// * `header` - The heading text.
+#[cfg(feature = "axum")]
+#[allow(dead_code)]
+fn log_h2(header: &str) {
+    log_header(header, &get_hashtags(5));
+}
+
+/// Pretty-prints a JSON value with colorized keys and indentation.
+///
+/// # Arguments
+///
+/// * `json` - The JSON value to print.
+/// * `level` - The current nesting depth for indentation.
+#[cfg(feature = "axum")]
+#[allow(dead_code)]
+pub(super) fn log_json(json: Value, level: i8) {
+    match json {
+        Value::Array(values) => {
+            log_array(values, level);
+        }
+        json => {
+            if let Some(json_object) = json.as_object() {
+                if level == 0 {
+                    println!("{{");
+                }
+
+                for (key, value) in json_object {
+                    print!("{}", get_spaces(level + 1));
+                    colorize_print(key, Colors::CyanFg);
+                    print!(": ");
+
+                    match value {
+                        Value::Array(values) => log_array(values.clone(), level + 1),
+                        Value::String(value) => {
+                            colorize_print(format!("\"{}\"", value), Colors::GreenFg);
+                            println!(",");
+                        }
+                        Value::Object(value) => {
+                            println!("{{");
+                            log_json(Value::Object(value.clone()), level + 2);
+                            print!("{}", get_spaces(level + 1));
+                            println!("}},");
+                        }
+                        value => {
+                            colorize_print(value.to_string(), Colors::MagentaFg);
+                            println!(",");
+                        }
+                    }
+                }
+
+                if level == 0 {
+                    println!("}}");
+                }
+            }
+        }
+    }
+}
+
+/// Pretty-prints a JSON array with indentation at the given nesting level.
+///
+/// # Arguments
+///
+/// * `values` - The array elements to print.
+/// * `level` - The current nesting depth for indentation.
+#[cfg(feature = "axum")]
+#[allow(dead_code)]
+fn log_array(values: Vec<Value>, level: i8) {
+    if values.is_empty() {
+        println!("[],");
+        return;
+    }
+
+    if level > 0 {
+        print!("\n{}", get_spaces(level));
+    }
+
+    println!("[");
+
+    for (index, value) in values.iter().enumerate() {
+        print!("{}", get_spaces(level + 1));
+        println!("{{");
+        log_json(value.to_owned(), level + 2);
+        print!("{}", get_spaces(level + 1));
+
+        if index == values.len() - 1 {
+            println!("}}");
+        } else {
+            println!("}},");
+        }
+    }
+
+    if level > 0 {
+        print!("{}", get_spaces(level));
+    }
+
+    if level == 0 {
+        println!("]");
+    } else {
+        println!("],");
+    }
+}
+
+/// Prints HTTP headers with sensitive values redacted.
+///
+/// # Arguments
+///
+/// * `headers` - The HTTP header map to print.
+#[cfg(feature = "axum")]
+#[allow(dead_code)]
+pub(super) fn log_headers(headers: &HeaderMap) {
+    for (key, value) in headers {
+        colorize_print(format!("{}: ", key), Colors::CyanFg);
+        let value = value.to_str().unwrap_or("<non-utf8>");
+        let sanitized = sanitize_header_value(key.as_str(), value);
+        println!("{}", sanitized);
+    }
+}
+
+/// Prints a verbose HTTP request log with headers and optional body.
+///
+/// # Arguments
+///
+/// * `id` - Unique request identifier.
+/// * `method` - The HTTP method.
+/// * `route` - The request path.
+/// * `headers` - The request headers.
+/// * `req_body` - Optional redacted JSON body to log.
+#[cfg(feature = "axum")]
+#[allow(dead_code)]
+pub(super) fn log_request(
+    id: Uuid,
+    method: &Method,
+    route: &str,
+    headers: &HeaderMap,
+    req_body: Option<Value>,
+) {
+    log_h1("Request");
+
+    colorize_print("Request ID: ", Colors::CyanFg);
+    println!("{}\n", id);
+
+    colorize_print(format!("{} ", method), Colors::CyanFg);
+    println!("{}", route);
+
+    log_h2("Headers");
+    log_headers(headers);
+
+    if let Some(req_body) = req_body {
+        log_h2("Body");
+        log_json(req_body, 0);
+    }
+}
+
+/// Prints a verbose HTTP response log with status, duration, and optional body.
+///
+/// # Arguments
+///
+/// * `id` - Unique request identifier.
+/// * `status_code` - The HTTP response status.
+/// * `duration_ms` - Request processing time in milliseconds.
+/// * `res_body` - Optional redacted JSON body to log.
+#[cfg(feature = "axum")]
+#[allow(dead_code)]
+pub(super) fn log_response(
+    id: Uuid,
+    status_code: StatusCode,
+    duration_ms: u128,
+    res_body: Option<Value>,
+) {
+    log_h1("Response");
+
+    colorize_print("Request ID: ", Colors::CyanFg);
+    println!("{}\n", id);
+
+    colorize_print("Status Code: ", Colors::CyanFg);
+
+    match classify_status(status_code) {
+        StatusClass::Success => colorize_println(status_code.to_string(), Colors::GreenFg),
+        StatusClass::ClientError => colorize_println(status_code.to_string(), Colors::YellowFg),
+        StatusClass::ServerError => colorize_println(status_code.to_string(), Colors::RedFg),
+        StatusClass::Other => colorize_println(status_code.to_string(), Colors::MagentaFg),
+    }
+
+    colorize_print("Duration: ", Colors::CyanFg);
+    colorize_println(format!("{} ms", duration_ms), Colors::BlueFg);
+
+    if let Some(res_body) = res_body {
+        log_h2("Body");
+        log_json(res_body, 0);
+    }
+}
+
+/// Prints a single-line compact HTTP log: `[id] METHOD /path -> STATUS (duration ms)`.
+///
+/// # Arguments
+///
+/// * `id` - Unique request identifier.
+/// * `method` - The HTTP method.
+/// * `route` - The request path.
+/// * `status_code` - The HTTP response status.
+/// * `duration_ms` - Request processing time in milliseconds.
+#[cfg(feature = "axum")]
+#[allow(dead_code)]
+pub(super) fn log_compact_http(
+    id: Uuid,
+    method: &Method,
+    route: &str,
+    status_code: StatusCode,
+    duration_ms: u128,
+) {
+    colorize_print(format!("[{}] ", id), Colors::CyanFg);
+    colorize_print(format!("{} {} -> ", method, route), Colors::BlueFg);
+
+    match classify_status(status_code) {
+        StatusClass::Success => colorize_print(status_code.to_string(), Colors::GreenFg),
+        StatusClass::ClientError => colorize_print(status_code.to_string(), Colors::YellowFg),
+        StatusClass::ServerError => colorize_print(status_code.to_string(), Colors::RedFg),
+        StatusClass::Other => colorize_print(status_code.to_string(), Colors::MagentaFg),
+    }
+
+    colorize_println(format!(" ({} ms)", duration_ms), Colors::BlueFg);
+}
+
+/// Extracts the path suffix after `src/`, returning an empty string if not found.
+///
+/// # Arguments
+///
+/// * `path` - An optional full file path.
+///
+/// # Returns
+///
+/// The portion of the path after `src/`, or an empty [`String`] if
+/// `path` is `None` or does not contain `src/`.
+pub(super) fn extract_after_src(path: Option<&str>) -> String {
+    match path {
+        Some(path) => {
+            let src_prefix = "src/";
+
+            if let Some(start_index) = path.find(src_prefix) {
+                let start_index = start_index + src_prefix.len();
+                path[start_index..].to_string()
+            } else {
+                String::new()
+            }
+        }
+        None => String::new(),
+    }
+}
+
+/// Prints a verbose error record with file path, line number, and red coloring.
+///
+/// # Arguments
+///
+/// * `record` - The log record to print.
+pub(super) fn log_error(record: &Record<'_>) {
+    let hashtags = get_hashtags(6);
+    let error_header = format!("{} Error {}", hashtags, hashtags);
+    let file_path = extract_after_src(record.file());
+    let line_number = record
+        .line()
+        .map(|line| line.to_string())
+        .unwrap_or_default();
+
+    println!();
+    colorize_println(error_header, Colors::RedFg);
+    colorize_println(format!("File: {}", file_path), Colors::RedFg);
+    colorize_println(format!("Line Number: {}", line_number), Colors::RedFg);
+    println!();
+    colorize_println(format!("{}", record.args()), Colors::RedFg);
+}
+
+/// Prints a verbose debug record with file path, line number, and yellow coloring.
+///
+/// # Arguments
+///
+/// * `record` - The log record to print.
+pub(super) fn log_debug(record: &Record<'_>) {
+    let hashtags = get_hashtags(6);
+    let debug_header = format!("{} Debug {}", hashtags, hashtags);
+    let file_path = extract_after_src(record.file());
+    let line_number = record
+        .line()
+        .map(|line| line.to_string())
+        .unwrap_or_default();
+
+    println!();
+    colorize_println(debug_header, Colors::YellowFg);
+    colorize_println(format!("File: {}", file_path), Colors::YellowFg);
+    colorize_println(format!("Line Number: {}", line_number), Colors::YellowFg);
+    println!();
+    colorize_println(format!("{}", record.args()), Colors::YellowFg);
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "axum")]
+    use axum::http::StatusCode;
+
+    #[cfg(feature = "axum")]
+    use super::{StatusClass, classify_status};
+    use super::{extract_after_src, get_hashtags, get_spaces};
+
+    #[cfg(feature = "axum")]
+    #[test]
+    fn classify_status_maps_expected_classes() {
+        assert_eq!(classify_status(StatusCode::OK), StatusClass::Success);
+        assert_eq!(
+            classify_status(StatusCode::BAD_REQUEST),
+            StatusClass::ClientError
+        );
+        assert_eq!(
+            classify_status(StatusCode::INTERNAL_SERVER_ERROR),
+            StatusClass::ServerError
+        );
+        assert_eq!(
+            classify_status(StatusCode::SWITCHING_PROTOCOLS),
+            StatusClass::Other
+        );
+    }
+
+    #[test]
+    fn extract_after_src_returns_relative_suffix() {
+        let extracted = extract_after_src(Some("/tmp/project/src/core/logger/mod.rs"));
+        assert_eq!(extracted, "core/logger/mod.rs");
+    }
+
+    #[test]
+    fn extract_after_src_returns_empty_when_src_not_found() {
+        let extracted = extract_after_src(Some("/tmp/project/core/logger/mod.rs"));
+        assert!(extracted.is_empty());
+    }
+
+    #[test]
+    fn extract_after_src_returns_empty_for_none() {
+        let extracted = extract_after_src(None);
+        assert!(extracted.is_empty());
+    }
+
+    #[test]
+    fn banner_and_indent_helpers_are_deterministic() {
+        assert_eq!(get_hashtags(0), "");
+        assert_eq!(get_hashtags(3), "###");
+        assert_eq!(get_spaces(0), "");
+        assert_eq!(get_spaces(2), "    ");
+    }
+}

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,0 +1,99 @@
+//! Log level parsing and conversion helpers.
+
+use log::{Level, LevelFilter};
+
+/// Parses a string into a [`LevelFilter`].
+///
+/// Matching is case-insensitive and trims surrounding whitespace.
+/// Unrecognized values default to [`LevelFilter::Info`].
+///
+/// # Arguments
+///
+/// * `log_level` - The log level string (for example, `"debug"` or `"info"`).
+///
+/// # Returns
+///
+/// The corresponding [`LevelFilter`], or [`LevelFilter::Info`] for
+/// unrecognized values.
+pub fn parse_level_filter(log_level: &str) -> LevelFilter {
+    match log_level.trim().to_ascii_lowercase().as_str() {
+        "off" => LevelFilter::Off,
+        "error" => LevelFilter::Error,
+        "warn" => LevelFilter::Warn,
+        "info" => LevelFilter::Info,
+        "debug" => LevelFilter::Debug,
+        "trace" => LevelFilter::Trace,
+        _ => LevelFilter::Info,
+    }
+}
+
+/// Converts a [`LevelFilter`] to a [`Level`].
+///
+/// Maps [`LevelFilter::Off`] to [`Level::Error`] so that a logger can still be
+/// initialized even when logging is disabled.
+///
+/// # Arguments
+///
+/// * `level_filter` - The filter to convert.
+///
+/// # Returns
+///
+/// The corresponding [`Level`], with [`LevelFilter::Off`] mapped to
+/// [`Level::Error`].
+pub fn level_for_logger(level_filter: LevelFilter) -> Level {
+    match level_filter {
+        LevelFilter::Off | LevelFilter::Error => Level::Error,
+        LevelFilter::Warn => Level::Warn,
+        LevelFilter::Info => Level::Info,
+        LevelFilter::Debug => Level::Debug,
+        LevelFilter::Trace => Level::Trace,
+    }
+}
+
+/// Returns `true` if the given filter is [`LevelFilter::Off`].
+///
+/// # Arguments
+///
+/// * `level_filter` - The filter to check.
+///
+/// # Returns
+///
+/// `true` if the filter is [`LevelFilter::Off`].
+pub fn is_off(level_filter: LevelFilter) -> bool {
+    matches!(level_filter, LevelFilter::Off)
+}
+
+#[cfg(test)]
+mod tests {
+    use log::{Level, LevelFilter};
+
+    use super::{is_off, level_for_logger, parse_level_filter};
+
+    #[test]
+    fn parse_level_filter_handles_expected_values() {
+        assert_eq!(parse_level_filter("off"), LevelFilter::Off);
+        assert_eq!(parse_level_filter("error"), LevelFilter::Error);
+        assert_eq!(parse_level_filter("warn"), LevelFilter::Warn);
+        assert_eq!(parse_level_filter("info"), LevelFilter::Info);
+        assert_eq!(parse_level_filter("debug"), LevelFilter::Debug);
+        assert_eq!(parse_level_filter("trace"), LevelFilter::Trace);
+        assert_eq!(parse_level_filter("invalid"), LevelFilter::Info);
+    }
+
+    #[test]
+    fn parse_level_filter_is_case_and_whitespace_insensitive() {
+        assert_eq!(parse_level_filter(" DEBUG "), LevelFilter::Debug);
+    }
+
+    #[test]
+    fn level_for_logger_maps_off_to_error_for_init() {
+        assert_eq!(level_for_logger(LevelFilter::Off), Level::Error);
+        assert_eq!(level_for_logger(LevelFilter::Info), Level::Info);
+    }
+
+    #[test]
+    fn is_off_detects_only_off() {
+        assert!(is_off(LevelFilter::Off));
+        assert!(!is_off(LevelFilter::Error));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,28 @@
+mod backend;
+mod formatting;
 pub mod level;
+#[cfg(any(feature = "axum", test))]
+mod redaction;
 
+pub use backend::Logger;
 pub use level::{is_off, level_for_logger, parse_level_filter};
+/// Convenience re-exports of the [`log`] facade macros.
+pub use log::{debug, error, info, trace, warn};
+
+/// Logs an informational message using the semantic message target.
+///
+/// # Arguments
+///
+/// * `message` - The message text to emit.
+pub fn log_message(message: &str) {
+    log::info!(target: backend::MESSAGE_TARGET, "{}", message);
+}
+
+/// Logs a success message using the semantic success target.
+///
+/// # Arguments
+///
+/// * `message` - The message text to emit.
+pub fn log_success(message: &str) {
+    log::info!(target: backend::SUCCESS_TARGET, "{}", message);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,13 @@
 //! # Native logger
 //!
 //! ```no_run
-//! use goggin_rs_logger::{Logger, log_message, log_success};
+//! use goggin_rs_logger::{Logger, info, log_message, log_success};
 //!
 //! fn main() {
 //!     Logger::setup_logging("info", false);
 //!
 //!     log_message("starting application");
-//!     log::info!("ready");
+//!     info!("ready");
 //!     log_success("startup complete");
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,108 @@
+//! Logging utilities extracted from GigLog.
+//!
+//! `goggin-rs-logger` provides a small [`log`] facade backend with colorized
+//! terminal output, semantic status helpers, optional Axum HTTP middleware, and
+//! an optional browser-to-server relay for Leptos/WASM applications.
+//!
+//! # Feature flags
+//!
+//! * No feature flags: native logger setup, level parsing helpers, semantic
+//!   [`log_message`] and [`log_success`] helpers, and [`log`] macro re-exports.
+//! * `axum`: enables `HttpLoggingConfig`, Axum request/response middleware,
+//!   and the server-side relay receiver APIs.
+//! * `leptos`: enables `WebLoggerConfig` and browser-side relay logger setup.
+//! * `axum` + `leptos`: enables both sides of the browser-to-server relay.
+//!
+//! # Native logger
+//!
+//! ```no_run
+//! use goggin_rs_logger::{Logger, log_message, log_success};
+//!
+//! fn main() {
+//!     Logger::setup_logging("info", false);
+//!
+//!     log_message("starting application");
+//!     log::info!("ready");
+//!     log_success("startup complete");
+//! }
+//! ```
+//!
+//! # Axum request and response logging
+//!
+//! Enable the `axum` feature to use `Logger::log_request_and_response` as
+//! middleware.
+//!
+//! ```no_run
+//! # #[cfg(feature = "axum")]
+//! # {
+//! use axum::{Router, middleware};
+//! use goggin_rs_logger::{HttpLoggingConfig, Logger};
+//!
+//! fn app() -> Router {
+//!     Router::new().route_layer(middleware::from_fn_with_state(
+//!         HttpLoggingConfig::default(),
+//!         Logger::log_request_and_response,
+//!     ))
+//! }
+//! # }
+//! ```
+//!
+//! # Leptos/WASM browser relay
+//!
+//! Enable the `leptos` feature to install a browser logger that forwards
+//! frontend records as JSON relay payloads.
+//!
+//! ```no_run
+//! # #[cfg(feature = "leptos")]
+//! # {
+//! use goggin_rs_logger::{
+//!     WebLoggerConfig, init_web_logging, init_web_logging_with_config,
+//! };
+//!
+//! fn install_default_logger() -> Result<(), log::SetLoggerError> {
+//!     init_web_logging("info")?;
+//!     Ok(())
+//! }
+//!
+//! fn install_custom_logger() -> Result<(), log::SetLoggerError> {
+//!     let config = WebLoggerConfig::new("debug").with_endpoint("/internal/web-log");
+//!     init_web_logging_with_config(config)?;
+//!     Ok(())
+//! }
+//! # }
+//! ```
+//!
+//! # Axum relay receiver
+//!
+//! Enable the `axum` feature to receive browser logs on the server. The browser
+//! emitter posts [`RelayLogPayload`] values to
+//! `DEFAULT_WEB_LOG_RELAY_ENDPOINT` by default. The receiver formats each
+//! payload and forwards every formatted line to a caller-provided
+//! `RelayLogSink`.
+//!
+//! ```no_run
+//! # #[cfg(feature = "axum")]
+//! # {
+//! use std::sync::Arc;
+//!
+//! use axum::Router;
+//! use goggin_rs_logger::{RelayLogSink, RelayReceiverState, relay_router};
+//!
+//! fn app() -> Router {
+//!     let sink: RelayLogSink = Arc::new(|line| println!("{line}"));
+//!     let relay_state = RelayReceiverState::new(sink, false);
+//!
+//!     Router::new().merge(relay_router(relay_state))
+//! }
+//! # }
+//! ```
+//!
+//! The relay payload schema is stable across the emitter and receiver:
+//! `level`, `message`, optional `target`, optional `file`, and optional `line`.
+//! The default endpoint is `/_leptos/web-log`; browser applications can choose
+//! a different path with `WebLoggerConfig::with_endpoint` and servers can
+//! mount `relay_router` anywhere that matches the emitted path.
+
 mod backend;
 mod formatting;
 pub mod level;
@@ -29,6 +134,10 @@ pub use relay::{WebLoggerConfig, init_web_logging, init_web_logging_with_config}
 /// # Arguments
 ///
 /// * `message` - The message text to emit.
+///
+/// # Returns
+///
+/// This function does not return a value.
 pub fn log_message(message: &str) {
     log::info!(target: backend::MESSAGE_TARGET, "{}", message);
 }
@@ -38,6 +147,10 @@ pub fn log_message(message: &str) {
 /// # Arguments
 ///
 /// * `message` - The message text to emit.
+///
+/// # Returns
+///
+/// This function does not return a value.
 pub fn log_success(message: &str) {
     log::info!(target: backend::SUCCESS_TARGET, "{}", message);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,16 @@ pub use level::{is_off, level_for_logger, parse_level_filter};
 pub use log::{debug, error, info, trace, warn};
 #[cfg(feature = "axum")]
 pub use middleware::HttpLoggingConfig;
+#[cfg(any(feature = "axum", feature = "leptos"))]
+pub use relay::DEFAULT_WEB_LOG_RELAY_ENDPOINT;
 pub use relay::RelayLogPayload;
-#[cfg(feature = "leptos")]
+#[cfg(feature = "axum")]
 pub use relay::{
-    DEFAULT_WEB_LOG_RELAY_ENDPOINT, WebLoggerConfig, init_web_logging, init_web_logging_with_config,
+    RelayLogSink, RelayReceiverState, format_relay_line, relay_log_handler, relay_router,
+    split_formatted_lines,
 };
+#[cfg(feature = "leptos")]
+pub use relay::{WebLoggerConfig, init_web_logging, init_web_logging_with_config};
 
 /// Logs an informational message using the semantic message target.
 ///
@@ -50,5 +55,49 @@ mod leptos_public_api_tests {
         let _: fn(&'static str) -> Result<WebLoggerConfig, log::SetLoggerError> = init_web_logging;
         let _: fn(WebLoggerConfig) -> Result<WebLoggerConfig, log::SetLoggerError> =
             init_web_logging_with_config;
+    }
+}
+
+#[cfg(all(test, feature = "axum"))]
+mod axum_public_api_tests {
+    use std::{future::Future, sync::Arc};
+
+    use axum::{Json, extract::State, http::StatusCode};
+
+    use super::{
+        DEFAULT_WEB_LOG_RELAY_ENDPOINT, RelayLogPayload, RelayLogSink, RelayReceiverState,
+        format_relay_line, relay_log_handler, relay_router, split_formatted_lines,
+    };
+
+    #[test]
+    fn axum_relay_public_api_is_exported_from_crate_root() {
+        let _: &'static str = DEFAULT_WEB_LOG_RELAY_ENDPOINT;
+        let sink: RelayLogSink = Arc::new(|_| {});
+        let state = RelayReceiverState::new(sink, true);
+        let _: fn(&RelayLogPayload, bool) -> String = format_relay_line;
+        let _: fn(&str) -> Vec<String> = split_formatted_lines;
+        let _ = relay_router(state);
+    }
+
+    #[test]
+    fn axum_relay_handler_return_type_is_status_code() {
+        fn assert_status_future<F>(_future: F)
+        where
+            F: Future<Output = StatusCode>,
+        {
+        }
+
+        let state = RelayReceiverState::new(Arc::new(|_| {}), false);
+        assert_status_future(relay_log_handler(State(state), Json(sample_payload())));
+    }
+
+    fn sample_payload() -> RelayLogPayload {
+        RelayLogPayload {
+            level: "info".to_string(),
+            message: "hello".to_string(),
+            target: None,
+            file: None,
+            line: None,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod level;
 mod middleware;
 #[cfg(any(feature = "axum", test))]
 mod redaction;
+pub mod relay;
 
 pub use backend::Logger;
 pub use level::{is_off, level_for_logger, parse_level_filter};
@@ -12,6 +13,7 @@ pub use level::{is_off, level_for_logger, parse_level_filter};
 pub use log::{debug, error, info, trace, warn};
 #[cfg(feature = "axum")]
 pub use middleware::HttpLoggingConfig;
+pub use relay::RelayLogPayload;
 
 /// Logs an informational message using the semantic message target.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 mod backend;
 mod formatting;
 pub mod level;
+#[cfg(feature = "axum")]
+mod middleware;
 #[cfg(any(feature = "axum", test))]
 mod redaction;
 
@@ -8,6 +10,8 @@ pub use backend::Logger;
 pub use level::{is_off, level_for_logger, parse_level_filter};
 /// Convenience re-exports of the [`log`] facade macros.
 pub use log::{debug, error, info, trace, warn};
+#[cfg(feature = "axum")]
+pub use middleware::HttpLoggingConfig;
 
 /// Logs an informational message using the semantic message target.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod level;
 
+pub use level::{is_off, level_for_logger, parse_level_filter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,10 @@ pub use log::{debug, error, info, trace, warn};
 #[cfg(feature = "axum")]
 pub use middleware::HttpLoggingConfig;
 pub use relay::RelayLogPayload;
+#[cfg(feature = "leptos")]
+pub use relay::{
+    DEFAULT_WEB_LOG_RELAY_ENDPOINT, WebLoggerConfig, init_web_logging, init_web_logging_with_config,
+};
 
 /// Logs an informational message using the semantic message target.
 ///
@@ -31,4 +35,20 @@ pub fn log_message(message: &str) {
 /// * `message` - The message text to emit.
 pub fn log_success(message: &str) {
     log::info!(target: backend::SUCCESS_TARGET, "{}", message);
+}
+
+#[cfg(all(test, feature = "leptos"))]
+mod leptos_public_api_tests {
+    use super::{
+        DEFAULT_WEB_LOG_RELAY_ENDPOINT, WebLoggerConfig, init_web_logging,
+        init_web_logging_with_config,
+    };
+
+    #[test]
+    fn leptos_public_api_is_exported_from_crate_root() {
+        let _: &'static str = DEFAULT_WEB_LOG_RELAY_ENDPOINT;
+        let _: fn(&'static str) -> Result<WebLoggerConfig, log::SetLoggerError> = init_web_logging;
+        let _: fn(WebLoggerConfig) -> Result<WebLoggerConfig, log::SetLoggerError> =
+            init_web_logging_with_config;
+    }
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,0 +1,431 @@
+//! Axum middleware for logging HTTP requests and responses.
+//!
+//! Captures request method, path, headers, and optionally the JSON body, then
+//! logs the corresponding response with status code and duration. Sensitive
+//! headers and JSON fields are redacted before output.
+
+use std::time::Instant;
+
+use axum::{
+    body::{Body, HttpBody, to_bytes},
+    extract::{Request, State},
+    http::{
+        Method,
+        header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderMap},
+    },
+    middleware::Next,
+    response::Response,
+};
+use log::Level;
+use uuid::Uuid;
+
+use crate::{
+    Logger,
+    formatting::{log_compact_http, log_request, log_response},
+    redaction::parse_redacted_json,
+};
+
+/// Configuration for the HTTP logging middleware.
+#[derive(Debug, Clone)]
+pub struct HttpLoggingConfig {
+    /// Whether to capture and log request/response bodies.
+    pub body_enabled: bool,
+    /// Maximum body size in bytes that will be buffered for logging.
+    pub max_body_bytes: usize,
+    /// Use verbose multi-line output instead of compact single-line format.
+    pub verbose: bool,
+}
+
+impl HttpLoggingConfig {
+    /// Creates a new configuration with the given settings.
+    ///
+    /// # Arguments
+    ///
+    /// * `body_enabled` - Whether to capture and log request/response bodies.
+    /// * `max_body_bytes` - Maximum body size in bytes that will be buffered
+    ///   for logging.
+    /// * `verbose` - Use verbose multi-line output instead of compact
+    ///   single-line format.
+    ///
+    /// # Returns
+    ///
+    /// A new [`HttpLoggingConfig`] instance.
+    pub fn new(body_enabled: bool, max_body_bytes: usize, verbose: bool) -> Self {
+        Self {
+            body_enabled,
+            max_body_bytes,
+            verbose,
+        }
+    }
+}
+
+/// Defaults to body logging disabled, 16 KB max body size, and verbose output.
+impl Default for HttpLoggingConfig {
+    fn default() -> Self {
+        Self {
+            body_enabled: false,
+            max_body_bytes: 16 * 1024,
+            verbose: true,
+        }
+    }
+}
+
+impl Logger {
+    /// Axum middleware that logs each HTTP request and its response.
+    ///
+    /// In verbose mode, prints detailed headers and bodies; otherwise prints a
+    /// compact one-line summary. Body logging is gated on
+    /// [`HttpLoggingConfig::body_enabled`] and respects the configured
+    /// [`max_body_bytes`](HttpLoggingConfig::max_body_bytes) limit.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The [`HttpLoggingConfig`] extracted from Axum state.
+    /// * `request` - The incoming HTTP request.
+    /// * `next` - The next middleware or handler in the chain.
+    ///
+    /// # Returns
+    ///
+    /// The HTTP [`Response`] produced by downstream handlers.
+    pub async fn log_request_and_response(
+        State(config): State<HttpLoggingConfig>,
+        request: Request,
+        next: Next,
+    ) -> Response {
+        if !log::log_enabled!(Level::Info) {
+            return next.run(request).await;
+        }
+
+        let request_id = Uuid::new_v4();
+        let use_verbose_http_logs = config.verbose || config.body_enabled;
+        let (request_parts, request_body) = request.into_parts();
+        let method = request_parts.method.clone();
+        let path = request_parts.uri.path().to_string();
+        let headers = request_parts.headers.clone();
+
+        let (logged_request_body, request_body_for_next) = if should_attempt_request_body_logging(
+            &method, &headers, &config,
+        ) {
+            match to_bytes(request_body, config.max_body_bytes).await {
+                Ok(bytes) => {
+                    let logged_body = parse_redacted_json(&bytes);
+                    (logged_body, Body::from(bytes))
+                }
+                Err(error) => {
+                    log::error!(
+                        "Skipping request body logging for request {} (failed to buffer request body: {})",
+                        request_id,
+                        error
+                    );
+
+                    (None, Body::empty())
+                }
+            }
+        } else {
+            (None, request_body)
+        };
+
+        let request = Request::from_parts(request_parts, request_body_for_next);
+
+        if use_verbose_http_logs {
+            log_request(request_id, &method, &path, &headers, logged_request_body);
+        }
+
+        let started_at = Instant::now();
+        let response = next.run(request).await;
+        let duration_ms = started_at.elapsed().as_millis();
+        let status = response.status();
+
+        if !use_verbose_http_logs {
+            log_compact_http(request_id, &method, &path, status, duration_ms);
+            return response;
+        }
+
+        let (response_parts, response_body) = response.into_parts();
+        let response_body_size_hint_upper = response_body.size_hint().upper();
+
+        if !should_attempt_response_body_logging(
+            &response_parts.headers,
+            response_body_size_hint_upper,
+            &config,
+        ) {
+            log_response(request_id, status, duration_ms, None);
+            return Response::from_parts(response_parts, response_body);
+        }
+
+        let (logged_response_body, response_body_for_client) = match to_bytes(
+            response_body,
+            config.max_body_bytes,
+        )
+        .await
+        {
+            Ok(bytes) => {
+                let logged_body = parse_redacted_json(&bytes);
+                (logged_body, Body::from(bytes))
+            }
+            Err(error) => {
+                log::error!(
+                    "Skipping response body logging for request {} (failed to buffer response body: {})",
+                    request_id,
+                    error
+                );
+
+                (None, Body::empty())
+            }
+        };
+
+        log_response(request_id, status, duration_ms, logged_response_body);
+
+        Response::from_parts(response_parts, response_body_for_client)
+    }
+}
+
+/// Returns `true` if the request body should be logged based on method,
+/// content type, and size.
+///
+/// # Arguments
+///
+/// * `method` - The HTTP method of the request.
+/// * `headers` - The request headers.
+/// * `config` - The logging configuration.
+///
+/// # Returns
+///
+/// `true` if the body should be captured for logging.
+fn should_attempt_request_body_logging(
+    method: &Method,
+    headers: &HeaderMap,
+    config: &HttpLoggingConfig,
+) -> bool {
+    if !config.body_enabled {
+        return false;
+    }
+
+    if matches!(method, &Method::GET | &Method::DELETE | &Method::HEAD) {
+        return false;
+    }
+
+    if !is_json_content_type(headers) {
+        return false;
+    }
+
+    match content_length(headers) {
+        Some(length) => length <= config.max_body_bytes,
+        None => false,
+    }
+}
+
+/// Returns `true` if the response body should be logged based on content type
+/// and size.
+///
+/// # Arguments
+///
+/// * `headers` - The response headers.
+/// * `body_size_hint_upper` - Optional upper bound of the body size from the
+///   response body's size hint.
+/// * `config` - The logging configuration.
+///
+/// # Returns
+///
+/// `true` if the body should be captured for logging.
+fn should_attempt_response_body_logging(
+    headers: &HeaderMap,
+    body_size_hint_upper: Option<u64>,
+    config: &HttpLoggingConfig,
+) -> bool {
+    if !config.body_enabled {
+        return false;
+    }
+
+    if !is_json_content_type(headers) {
+        return false;
+    }
+
+    match content_length(headers)
+        .or_else(|| body_size_hint_upper.and_then(|upper_bound| usize::try_from(upper_bound).ok()))
+    {
+        Some(length) => length <= config.max_body_bytes,
+        None => false,
+    }
+}
+
+/// Returns `true` if the `Content-Type` header indicates JSON.
+///
+/// # Arguments
+///
+/// * `headers` - The HTTP header map to inspect.
+///
+/// # Returns
+///
+/// `true` if the `Content-Type` contains `application/json` or `+json`.
+fn is_json_content_type(headers: &HeaderMap) -> bool {
+    let content_type = headers
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.to_ascii_lowercase());
+
+    match content_type {
+        Some(content_type) => {
+            content_type.contains("application/json") || content_type.contains("+json")
+        }
+        None => false,
+    }
+}
+
+/// Parses the `Content-Length` header as a `usize`, returning `None` if absent
+/// or invalid.
+///
+/// # Arguments
+///
+/// * `headers` - The HTTP header map to inspect.
+///
+/// # Returns
+///
+/// The parsed content length, or `None` if the header is missing or cannot be
+/// parsed.
+fn content_length(headers: &HeaderMap) -> Option<usize> {
+    headers
+        .get(CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<usize>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{Method, header};
+
+    use super::{
+        HttpLoggingConfig, should_attempt_request_body_logging,
+        should_attempt_response_body_logging,
+    };
+
+    #[test]
+    fn request_body_logging_requires_json_with_allowed_method_and_size() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("8"),
+        );
+
+        let config = HttpLoggingConfig {
+            body_enabled: true,
+            max_body_bytes: 16,
+            verbose: true,
+        };
+
+        assert!(should_attempt_request_body_logging(
+            &Method::POST,
+            &headers,
+            &config
+        ));
+        assert!(!should_attempt_request_body_logging(
+            &Method::GET,
+            &headers,
+            &config
+        ));
+
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("32"),
+        );
+
+        assert!(!should_attempt_request_body_logging(
+            &Method::POST,
+            &headers,
+            &config
+        ));
+    }
+
+    #[test]
+    fn response_body_logging_uses_content_length_or_size_hint() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("48"),
+        );
+
+        let config = HttpLoggingConfig {
+            body_enabled: true,
+            max_body_bytes: 128,
+            verbose: true,
+        };
+
+        assert!(should_attempt_response_body_logging(
+            &headers, None, &config
+        ));
+
+        headers.remove(header::CONTENT_LENGTH);
+
+        assert!(should_attempt_response_body_logging(
+            &headers,
+            Some(48),
+            &config
+        ));
+        assert!(!should_attempt_response_body_logging(
+            &headers,
+            Some(256),
+            &config
+        ));
+        assert!(!should_attempt_response_body_logging(
+            &headers, None, &config
+        ));
+    }
+
+    #[test]
+    fn body_logging_is_disabled_outside_development() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("8"),
+        );
+
+        let config = HttpLoggingConfig {
+            body_enabled: false,
+            max_body_bytes: 128,
+            verbose: true,
+        };
+
+        assert!(!should_attempt_request_body_logging(
+            &Method::POST,
+            &headers,
+            &config
+        ));
+    }
+
+    #[test]
+    fn body_logging_does_not_depend_on_verbose_flag() {
+        let mut headers = header::HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            header::HeaderValue::from_static("application/json"),
+        );
+        headers.insert(
+            header::CONTENT_LENGTH,
+            header::HeaderValue::from_static("8"),
+        );
+
+        let config = HttpLoggingConfig {
+            body_enabled: true,
+            max_body_bytes: 128,
+            verbose: false,
+        };
+
+        assert!(should_attempt_request_body_logging(
+            &Method::POST,
+            &headers,
+            &config
+        ));
+    }
+}

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -1,0 +1,199 @@
+//! Sensitive value redaction for JSON bodies and HTTP headers.
+//!
+//! Replaces values of keys that match known sensitive patterns (passwords,
+//! tokens, secrets, API keys) with `"(hidden)"` before they reach log output.
+
+use serde_json::{Value, from_slice};
+
+/// Parses bytes as JSON and redacts all sensitive fields, returning `None` for empty or invalid input.
+///
+/// # Arguments
+///
+/// * `bytes` - The raw byte slice to parse.
+///
+/// # Returns
+///
+/// The redacted JSON [`Value`], or `None` if `bytes` is empty or
+/// not valid JSON.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) fn parse_redacted_json(bytes: &[u8]) -> Option<Value> {
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let mut value = from_slice::<Value>(bytes).ok()?;
+    redact_json_value(&mut value);
+
+    Some(value)
+}
+
+/// Recursively replaces values of sensitive keys with `"(hidden)"`.
+///
+/// # Arguments
+///
+/// * `value` - The JSON value to redact in place.
+pub(super) fn redact_json_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, value) in map.iter_mut() {
+                if is_sensitive_json_key(key) {
+                    *value = Value::String("(hidden)".to_string());
+                } else {
+                    redact_json_value(value);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                redact_json_value(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Returns `true` if the JSON key matches a sensitive pattern (case-insensitive).
+///
+/// # Arguments
+///
+/// * `key` - The JSON field name to check.
+///
+/// # Returns
+///
+/// `true` if the key matches a known sensitive pattern.
+pub(super) fn is_sensitive_json_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+
+    matches!(
+        key.as_str(),
+        "password"
+            | "confirm"
+            | "token"
+            | "access_token"
+            | "refresh_token"
+            | "auth_code"
+            | "secret"
+            | "api_key"
+    ) || key.contains("token")
+        || key.contains("secret")
+        || key.contains("password")
+}
+
+/// Returns `"(hidden)"` for sensitive headers, or the original value otherwise.
+///
+/// # Arguments
+///
+/// * `name` - The header name.
+/// * `value` - The header value.
+///
+/// # Returns
+///
+/// `"(hidden)"` if the header is sensitive, or the original `value`.
+pub(super) fn sanitize_header_value(name: &str, value: &str) -> String {
+    if is_sensitive_header(name) {
+        "(hidden)".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+/// Returns `true` if the header name matches a sensitive pattern (case-insensitive).
+///
+/// # Arguments
+///
+/// * `name` - The header name to check.
+///
+/// # Returns
+///
+/// `true` if the header name matches a known sensitive pattern.
+pub(super) fn is_sensitive_header(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+
+    matches!(
+        name.as_str(),
+        "authorization" | "cookie" | "set-cookie" | "x-api-key" | "x-auth-token"
+    ) || name.contains("token")
+        || name.contains("secret")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{parse_redacted_json, redact_json_value, sanitize_header_value};
+
+    #[test]
+    fn redact_json_masks_sensitive_keys() {
+        let mut value = json!({
+            "password": "secret",
+            "nested": {
+                "auth_code": "123456",
+                "name": "Taylor"
+            }
+        });
+
+        redact_json_value(&mut value);
+
+        assert_eq!(value["password"], "(hidden)");
+        assert_eq!(value["nested"]["auth_code"], "(hidden)");
+        assert_eq!(value["nested"]["name"], "Taylor");
+    }
+
+    #[test]
+    fn redact_json_masks_case_insensitive_and_substring_keys() {
+        let mut value = json!({
+            "Access_Token": "abc",
+            "dbPasswordHash": "hashed",
+            "nested": {
+                "clientSecret": "top-secret",
+                "safe": "visible"
+            },
+            "items": [
+                {
+                    "refresh_token": "token-1"
+                },
+                {
+                    "note": "still-visible"
+                }
+            ]
+        });
+
+        redact_json_value(&mut value);
+
+        assert_eq!(value["Access_Token"], "(hidden)");
+        assert_eq!(value["dbPasswordHash"], "(hidden)");
+        assert_eq!(value["nested"]["clientSecret"], "(hidden)");
+        assert_eq!(value["nested"]["safe"], "visible");
+        assert_eq!(value["items"][0]["refresh_token"], "(hidden)");
+        assert_eq!(value["items"][1]["note"], "still-visible");
+    }
+
+    #[test]
+    fn sanitize_header_value_masks_sensitive_headers() {
+        assert_eq!(
+            sanitize_header_value("Authorization", "Bearer abc"),
+            "(hidden)"
+        );
+        assert_eq!(sanitize_header_value("X-Auth-Token", "abc"), "(hidden)");
+        assert_eq!(
+            sanitize_header_value("X-Client-Secret-Key", "xyz"),
+            "(hidden)"
+        );
+        assert_eq!(sanitize_header_value("X-Request-Id", "123"), "123");
+    }
+
+    #[test]
+    fn parse_redacted_json_returns_none_for_invalid_json() {
+        let value = parse_redacted_json(b"not-json");
+        assert!(value.is_none());
+    }
+
+    #[test]
+    fn parse_redacted_json_redacts_sensitive_fields() {
+        let value = parse_redacted_json(br#"{"password":"abc","name":"Taylor"}"#)
+            .expect("expected valid JSON");
+
+        assert_eq!(value["password"], "(hidden)");
+        assert_eq!(value["name"], "Taylor");
+    }
+}

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -71,11 +71,22 @@ pub(super) fn is_sensitive_json_key(key: &str) -> bool {
             | "token"
             | "access_token"
             | "refresh_token"
+            | "authorization"
+            | "auth"
             | "auth_code"
+            | "jwt"
+            | "session"
+            | "session_id"
+            | "cookie"
+            | "set_cookie"
             | "secret"
             | "api_key"
     ) || key.contains("token")
+        || key.contains("authorization")
         || key.contains("secret")
+        || key.contains("session")
+        || key.contains("cookie")
+        || key.contains("jwt")
         || key.contains("password")
 }
 
@@ -114,6 +125,8 @@ pub(super) fn is_sensitive_header(name: &str) -> bool {
         "authorization" | "cookie" | "set-cookie" | "x-api-key" | "x-auth-token"
     ) || name.contains("token")
         || name.contains("secret")
+        || name.contains("session")
+        || name.contains("jwt")
 }
 
 #[cfg(test)]
@@ -143,6 +156,10 @@ mod tests {
     fn redact_json_masks_case_insensitive_and_substring_keys() {
         let mut value = json!({
             "Access_Token": "abc",
+            "Authorization": "Bearer abc",
+            "session_id": "session-1",
+            "cookie": "sid=session-1",
+            "jwt": "ey...",
             "dbPasswordHash": "hashed",
             "nested": {
                 "clientSecret": "top-secret",
@@ -161,6 +178,10 @@ mod tests {
         redact_json_value(&mut value);
 
         assert_eq!(value["Access_Token"], "(hidden)");
+        assert_eq!(value["Authorization"], "(hidden)");
+        assert_eq!(value["session_id"], "(hidden)");
+        assert_eq!(value["cookie"], "(hidden)");
+        assert_eq!(value["jwt"], "(hidden)");
         assert_eq!(value["dbPasswordHash"], "(hidden)");
         assert_eq!(value["nested"]["clientSecret"], "(hidden)");
         assert_eq!(value["nested"]["safe"], "visible");
@@ -175,6 +196,8 @@ mod tests {
             "(hidden)"
         );
         assert_eq!(sanitize_header_value("X-Auth-Token", "abc"), "(hidden)");
+        assert_eq!(sanitize_header_value("X-Session-Id", "abc"), "(hidden)");
+        assert_eq!(sanitize_header_value("X-JWT", "abc"), "(hidden)");
         assert_eq!(
             sanitize_header_value("X-Client-Secret-Key", "xyz"),
             "(hidden)"

--- a/src/relay/emitter.rs
+++ b/src/relay/emitter.rs
@@ -1,0 +1,219 @@
+//! Browser-side log relay emitter for Leptos WASM applications.
+//!
+//! Captures records emitted through the [`log`] facade and forwards them to a
+//! server relay endpoint as [`RelayLogPayload`] JSON.
+
+use std::{
+    cell::{Cell, RefCell},
+    collections::VecDeque,
+};
+
+use gloo_net::http::Request;
+use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
+use wasm_bindgen_futures::spawn_local;
+
+use super::{DEFAULT_WEB_LOG_RELAY_ENDPOINT, RelayLogPayload};
+use crate::level::{is_off, parse_level_filter};
+
+const MAX_RELAY_QUEUE_LEN: usize = 1024;
+
+/// Stores resolved browser logger configuration values.
+#[derive(Debug, Clone, Copy)]
+pub struct WebLoggerConfig {
+    /// Configured level string used for parsing.
+    pub configured_level: &'static str,
+    /// Parsed [`LevelFilter`] used by the logger.
+    pub level_filter: LevelFilter,
+    /// Endpoint path used for browser-to-server log relay requests.
+    pub endpoint: &'static str,
+}
+
+impl WebLoggerConfig {
+    /// Creates a browser logger configuration from the compile-time web level.
+    ///
+    /// `WEB_LOG_LEVEL` takes precedence when it is set at compile time.
+    /// Otherwise, `default_level` is used.
+    pub fn new(default_level: &'static str) -> Self {
+        let configured_level = option_env!("WEB_LOG_LEVEL").unwrap_or(default_level);
+        let level_filter = parse_level_filter(configured_level);
+
+        Self {
+            configured_level,
+            level_filter,
+            endpoint: DEFAULT_WEB_LOG_RELAY_ENDPOINT,
+        }
+    }
+
+    /// Returns this configuration with a custom relay endpoint.
+    pub fn with_endpoint(self, endpoint: &'static str) -> Self {
+        Self { endpoint, ..self }
+    }
+}
+
+/// Implements a [`Log`] sink that relays frontend records over HTTP.
+struct WebRelayLogger;
+
+static WEB_RELAY_LOGGER: WebRelayLogger = WebRelayLogger;
+
+thread_local! {
+    static RELAY_QUEUE: RefCell<VecDeque<RelayLogPayload>> = RefCell::new(VecDeque::new());
+    static RELAY_SENDING: Cell<bool> = const { Cell::new(false) };
+    static RELAY_ENDPOINT: Cell<&'static str> = const { Cell::new(DEFAULT_WEB_LOG_RELAY_ENDPOINT) };
+}
+
+/// Initializes browser logging with the default relay endpoint.
+///
+/// Resolves the log level from `WEB_LOG_LEVEL`, updates the max log level, and
+/// installs the relay logger when the level is not `off`.
+pub fn init_web_logging(default_level: &'static str) -> Result<WebLoggerConfig, SetLoggerError> {
+    init_web_logging_with_config(WebLoggerConfig::new(default_level))
+}
+
+/// Initializes browser logging with the provided configuration.
+///
+/// Stores the configured endpoint before registering the logger so records
+/// emitted immediately after registration use the selected relay path.
+pub fn init_web_logging_with_config(
+    config: WebLoggerConfig,
+) -> Result<WebLoggerConfig, SetLoggerError> {
+    store_endpoint(config.endpoint);
+    log::set_max_level(config.level_filter);
+
+    if is_off(config.level_filter) {
+        return Ok(config);
+    }
+
+    log::set_logger(&WEB_RELAY_LOGGER)?;
+
+    Ok(config)
+}
+
+impl Log for WebRelayLogger {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let payload = RelayLogPayload {
+            level: record.level().to_string().to_ascii_lowercase(),
+            message: record.args().to_string(),
+            target: Some(record.target().to_string()),
+            file: record.file().map(str::to_string),
+            line: record.line(),
+        };
+
+        enqueue_payload(payload);
+    }
+
+    fn flush(&self) {}
+}
+
+/// Enqueues a relay payload and starts the sender task when idle.
+fn enqueue_payload(payload: RelayLogPayload) {
+    RELAY_QUEUE.with(|queue| {
+        let mut queue = queue.borrow_mut();
+        if queue.len() >= MAX_RELAY_QUEUE_LEN {
+            let _ = queue.pop_front();
+        }
+        queue.push_back(payload);
+    });
+
+    start_sender_if_needed();
+}
+
+/// Starts the async relay sender loop when it is not already running.
+fn start_sender_if_needed() {
+    let should_start = RELAY_SENDING.with(|sending| {
+        if sending.get() {
+            false
+        } else {
+            sending.set(true);
+            true
+        }
+    });
+
+    if !should_start {
+        return;
+    }
+
+    spawn_local(async {
+        loop {
+            let next = RELAY_QUEUE.with(|queue| queue.borrow_mut().pop_front());
+            match next {
+                Some(payload) => send_payload(payload).await,
+                None => {
+                    RELAY_SENDING.with(|sending| sending.set(false));
+                    break;
+                }
+            }
+        }
+    });
+}
+
+/// Sends a single relay payload to the configured backend endpoint.
+async fn send_payload(payload: RelayLogPayload) {
+    let request = match Request::post(configured_endpoint()).json(&payload) {
+        Ok(request) => request,
+        Err(_) => return,
+    };
+
+    let _ = request.send().await;
+}
+
+fn store_endpoint(endpoint: &'static str) {
+    RELAY_ENDPOINT.with(|stored_endpoint| stored_endpoint.set(endpoint));
+}
+
+fn configured_endpoint() -> &'static str {
+    RELAY_ENDPOINT.with(Cell::get)
+}
+
+#[cfg(test)]
+mod tests {
+    use log::LevelFilter;
+
+    use super::{
+        DEFAULT_WEB_LOG_RELAY_ENDPOINT, WebLoggerConfig, configured_endpoint,
+        init_web_logging_with_config,
+    };
+
+    #[test]
+    fn config_new_uses_default_endpoint() {
+        let config = WebLoggerConfig::new("debug");
+
+        assert_eq!(config.endpoint, DEFAULT_WEB_LOG_RELAY_ENDPOINT);
+    }
+
+    #[test]
+    fn config_with_endpoint_overrides_endpoint() {
+        let config = WebLoggerConfig {
+            configured_level: "info",
+            level_filter: LevelFilter::Info,
+            endpoint: DEFAULT_WEB_LOG_RELAY_ENDPOINT,
+        };
+
+        let config = config.with_endpoint("/custom/web-log");
+
+        assert_eq!(config.configured_level, "info");
+        assert_eq!(config.level_filter, LevelFilter::Info);
+        assert_eq!(config.endpoint, "/custom/web-log");
+    }
+
+    #[test]
+    fn init_with_config_stores_endpoint_before_registration() {
+        let config = WebLoggerConfig {
+            configured_level: "off",
+            level_filter: LevelFilter::Off,
+            endpoint: "/custom/web-log",
+        };
+
+        let config = init_web_logging_with_config(config).expect("off level should not set logger");
+
+        assert_eq!(config.endpoint, "/custom/web-log");
+        assert_eq!(configured_endpoint(), "/custom/web-log");
+    }
+}

--- a/src/relay/emitter.rs
+++ b/src/relay/emitter.rs
@@ -33,6 +33,16 @@ impl WebLoggerConfig {
     ///
     /// `WEB_LOG_LEVEL` takes precedence when it is set at compile time.
     /// Otherwise, `default_level` is used.
+    ///
+    /// # Arguments
+    ///
+    /// * `default_level` - Fallback level string used when `WEB_LOG_LEVEL` is
+    ///   not set.
+    ///
+    /// # Returns
+    ///
+    /// A [`WebLoggerConfig`] using the resolved level and the default relay
+    /// endpoint.
     pub fn new(default_level: &'static str) -> Self {
         let configured_level = option_env!("WEB_LOG_LEVEL").unwrap_or(default_level);
         let level_filter = parse_level_filter(configured_level);
@@ -45,6 +55,15 @@ impl WebLoggerConfig {
     }
 
     /// Returns this configuration with a custom relay endpoint.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - Endpoint path used for browser-to-server relay requests.
+    ///
+    /// # Returns
+    ///
+    /// A [`WebLoggerConfig`] with the same level settings and the provided
+    /// endpoint.
     pub fn with_endpoint(self, endpoint: &'static str) -> Self {
         Self { endpoint, ..self }
     }
@@ -65,6 +84,19 @@ thread_local! {
 ///
 /// Resolves the log level from `WEB_LOG_LEVEL`, updates the max log level, and
 /// installs the relay logger when the level is not `off`.
+///
+/// # Arguments
+///
+/// * `default_level` - Fallback level string used when `WEB_LOG_LEVEL` is not
+///   set.
+///
+/// # Returns
+///
+/// The resolved [`WebLoggerConfig`] used to initialize browser logging.
+///
+/// # Errors
+///
+/// Returns [`SetLoggerError`] if another logger has already been installed.
 pub fn init_web_logging(default_level: &'static str) -> Result<WebLoggerConfig, SetLoggerError> {
     init_web_logging_with_config(WebLoggerConfig::new(default_level))
 }
@@ -73,6 +105,18 @@ pub fn init_web_logging(default_level: &'static str) -> Result<WebLoggerConfig, 
 ///
 /// Stores the configured endpoint before registering the logger so records
 /// emitted immediately after registration use the selected relay path.
+///
+/// # Arguments
+///
+/// * `config` - Resolved browser logger configuration.
+///
+/// # Returns
+///
+/// The [`WebLoggerConfig`] used to initialize browser logging.
+///
+/// # Errors
+///
+/// Returns [`SetLoggerError`] if another logger has already been installed.
 pub fn init_web_logging_with_config(
     config: WebLoggerConfig,
 ) -> Result<WebLoggerConfig, SetLoggerError> {

--- a/src/relay/emitter.rs
+++ b/src/relay/emitter.rs
@@ -75,7 +75,7 @@ struct WebRelayLogger;
 static WEB_RELAY_LOGGER: WebRelayLogger = WebRelayLogger;
 
 thread_local! {
-    static RELAY_QUEUE: RefCell<VecDeque<RelayLogPayload>> = RefCell::new(VecDeque::new());
+    static RELAY_QUEUE: RefCell<VecDeque<RelayLogPayload>> = const { RefCell::new(VecDeque::new()) };
     static RELAY_SENDING: Cell<bool> = const { Cell::new(false) };
     static RELAY_ENDPOINT: Cell<&'static str> = const { Cell::new(DEFAULT_WEB_LOG_RELAY_ENDPOINT) };
 }

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -1,0 +1,68 @@
+//! Shared browser-to-server log relay payloads.
+
+use serde::{Deserialize, Serialize};
+
+/// Stable JSON schema for a browser-to-server log relay payload.
+///
+/// This type defines the shared on-wire contract between relay emitters and
+/// receivers. The endpoint path is intentionally not part of the schema so
+/// applications can choose or configure their own relay route.
+#[derive(Serialize, Deserialize)]
+pub struct RelayLogPayload {
+    /// Log level name, such as `"error"`, `"warn"`, `"info"`, `"debug"`, or `"trace"`.
+    pub level: String,
+    /// Rendered log message.
+    pub message: String,
+    /// Optional log target/module path.
+    pub target: Option<String>,
+    /// Optional source file path reported by the caller.
+    pub file: Option<String>,
+    /// Optional source line number reported by the caller.
+    pub line: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::RelayLogPayload;
+
+    #[test]
+    fn serializes_relay_payload_fields() {
+        let payload = RelayLogPayload {
+            level: "info".to_string(),
+            message: "saved settings".to_string(),
+            target: Some("app::settings".to_string()),
+            file: Some("src/settings.rs".to_string()),
+            line: Some(42),
+        };
+
+        let value = serde_json::to_value(&payload).expect("payload should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "level": "info",
+                "message": "saved settings",
+                "target": "app::settings",
+                "file": "src/settings.rs",
+                "line": 42
+            })
+        );
+    }
+
+    #[test]
+    fn deserializes_missing_optional_fields_as_none() {
+        let payload: RelayLogPayload = serde_json::from_value(json!({
+            "level": "error",
+            "message": "request failed"
+        }))
+        .expect("payload should deserialize");
+
+        assert_eq!(payload.level, "error");
+        assert_eq!(payload.message, "request failed");
+        assert!(payload.target.is_none());
+        assert!(payload.file.is_none());
+        assert!(payload.line.is_none());
+    }
+}

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -4,9 +4,16 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "leptos")]
 mod emitter;
+#[cfg(feature = "axum")]
+mod receiver;
 
 #[cfg(feature = "leptos")]
 pub use emitter::{WebLoggerConfig, init_web_logging, init_web_logging_with_config};
+#[cfg(feature = "axum")]
+pub use receiver::{
+    RelayLogSink, RelayReceiverState, format_relay_line, relay_log_handler, relay_router,
+    split_formatted_lines,
+};
 
 /// Default endpoint path for browser-to-server log relay requests.
 pub const DEFAULT_WEB_LOG_RELAY_ENDPOINT: &str = "/_leptos/web-log";

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -1,4 +1,8 @@
 //! Shared browser-to-server log relay payloads.
+//!
+//! The relay contract uses [`RelayLogPayload`] as the JSON body posted by the
+//! browser emitter and accepted by the Axum receiver. Browser emitters post to
+//! [`DEFAULT_WEB_LOG_RELAY_ENDPOINT`] unless configured with a custom endpoint.
 
 use serde::{Deserialize, Serialize};
 
@@ -16,6 +20,9 @@ pub use receiver::{
 };
 
 /// Default endpoint path for browser-to-server log relay requests.
+///
+/// Browser emitters use this path unless `WebLoggerConfig::with_endpoint` is
+/// used to override it.
 pub const DEFAULT_WEB_LOG_RELAY_ENDPOINT: &str = "/_leptos/web-log";
 
 /// Stable JSON schema for a browser-to-server log relay payload.
@@ -23,6 +30,15 @@ pub const DEFAULT_WEB_LOG_RELAY_ENDPOINT: &str = "/_leptos/web-log";
 /// This type defines the shared on-wire contract between relay emitters and
 /// receivers. The endpoint path is intentionally not part of the schema so
 /// applications can choose or configure their own relay route.
+///
+/// # Fields
+///
+/// * `level` - Log level name such as `"error"`, `"warn"`, `"info"`,
+///   `"debug"`, or `"trace"`.
+/// * `message` - Rendered log message.
+/// * `target` - Optional log target or module path.
+/// * `file` - Optional source file path.
+/// * `line` - Optional source line number.
 #[derive(Serialize, Deserialize)]
 pub struct RelayLogPayload {
     /// Log level name, such as `"error"`, `"warn"`, `"info"`, `"debug"`, or `"trace"`.

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -2,6 +2,15 @@
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "leptos")]
+mod emitter;
+
+#[cfg(feature = "leptos")]
+pub use emitter::{WebLoggerConfig, init_web_logging, init_web_logging_with_config};
+
+/// Default endpoint path for browser-to-server log relay requests.
+pub const DEFAULT_WEB_LOG_RELAY_ENDPOINT: &str = "/_leptos/web-log";
+
 /// Stable JSON schema for a browser-to-server log relay payload.
 ///
 /// This type defines the shared on-wire contract between relay emitters and

--- a/src/relay/receiver.rs
+++ b/src/relay/receiver.rs
@@ -1,0 +1,388 @@
+//! Axum relay receiver for browser log payloads.
+//!
+//! Formats posted [`RelayLogPayload`] values with the same ANSI style used by
+//! the native logger, then forwards each formatted line to a caller-provided
+//! sink.
+
+use std::sync::Arc;
+
+use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
+
+use super::{DEFAULT_WEB_LOG_RELAY_ENDPOINT, RelayLogPayload};
+use crate::backend::{MESSAGE_TARGET, SUCCESS_TARGET};
+
+const ANSI_BLUE: &str = "\x1b[34m";
+const ANSI_GREEN: &str = "\x1b[32m";
+const ANSI_RED: &str = "\x1b[31m";
+const ANSI_YELLOW: &str = "\x1b[33m";
+const ANSI_MAGENTA: &str = "\x1b[35m";
+const ANSI_PURPLE: &str = "\x1b[35m";
+const ANSI_CLEAR: &str = "\x1b[0m";
+
+/// Receives formatted relay lines.
+pub type RelayLogSink = Arc<dyn Fn(String) + Send + Sync + 'static>;
+
+/// Shared state used by relay receiver routes.
+#[derive(Clone)]
+pub struct RelayReceiverState {
+    /// Receives each formatted output line.
+    pub sink: RelayLogSink,
+    /// Controls verbose multi-line formatting behavior.
+    pub verbose: bool,
+}
+
+impl RelayReceiverState {
+    /// Creates relay receiver state.
+    ///
+    /// # Arguments
+    ///
+    /// * `sink` - Callback invoked once for each formatted output line.
+    /// * `verbose` - Enables expanded multi-line formatting when `true`.
+    ///
+    /// # Returns
+    ///
+    /// A new [`RelayReceiverState`] instance.
+    pub fn new(sink: RelayLogSink, verbose: bool) -> Self {
+        Self { sink, verbose }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SemanticLogKind {
+    Message,
+    Success,
+}
+
+/// Classifies web log payload levels into relay formatting categories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WebLogLevel {
+    /// Represents error-level browser logs.
+    Error,
+    /// Represents warning-level browser logs.
+    Warn,
+    /// Represents info-level browser logs.
+    Info,
+    /// Represents debug-level browser logs.
+    Debug,
+    /// Represents trace-level browser logs.
+    Trace,
+}
+
+impl WebLogLevel {
+    /// Parses a raw level string into a normalized [`WebLogLevel`].
+    ///
+    /// # Arguments
+    ///
+    /// * `raw` - Raw level string from an incoming JSON payload.
+    ///
+    /// # Returns
+    ///
+    /// A parsed [`WebLogLevel`], defaulting to [`WebLogLevel::Info`].
+    fn parse(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "error" => Self::Error,
+            "warn" | "warning" => Self::Warn,
+            "debug" => Self::Debug,
+            "trace" => Self::Trace,
+            "info" => Self::Info,
+            _ => Self::Info,
+        }
+    }
+}
+
+/// Formats a relay payload into one or more ANSI-decorated lines.
+///
+/// # Arguments
+///
+/// * `payload` - Incoming web log payload.
+/// * `verbose` - Enables expanded multi-line formatting when `true`.
+///
+/// # Returns
+///
+/// A formatted string ready for newline splitting.
+pub fn format_relay_line(payload: &RelayLogPayload, verbose: bool) -> String {
+    let level = WebLogLevel::parse(&payload.level);
+    let message = payload.message.trim_end().to_string();
+    let semantic_kind = parse_semantic_log_kind(payload.target.as_deref());
+
+    if let Some(semantic_kind) = semantic_kind {
+        return format_semantic_line(semantic_kind, &message, verbose);
+    }
+
+    let file = payload
+        .file
+        .as_deref()
+        .map(extract_after_src)
+        .filter(|value| !value.is_empty())
+        .or_else(|| payload.target.clone())
+        .unwrap_or_default();
+    let line_number = payload
+        .line
+        .map(|line| line.to_string())
+        .unwrap_or_default();
+
+    if !verbose {
+        return format_non_verbose(level, &message);
+    }
+
+    match level {
+        WebLogLevel::Info => format!("\n{ANSI_BLUE}{message}{ANSI_CLEAR}"),
+        WebLogLevel::Error => format_error_like("Error", ANSI_RED, &file, &line_number, &message),
+        WebLogLevel::Debug => {
+            format_error_like("Debug", ANSI_YELLOW, &file, &line_number, &message)
+        }
+        WebLogLevel::Warn | WebLogLevel::Trace => format!(
+            "\n{ANSI_PURPLE}File: {file}{ANSI_CLEAR}\n{ANSI_PURPLE}Line Number: {line_number}{ANSI_CLEAR}\n{message}"
+        ),
+    }
+}
+
+/// Splits formatted output into line records while preserving blanks.
+///
+/// # Arguments
+///
+/// * `formatted` - Formatted relay output string.
+///
+/// # Returns
+///
+/// A vector of per-line strings suitable for log emission.
+pub fn split_formatted_lines(formatted: &str) -> Vec<String> {
+    formatted.split('\n').map(str::to_string).collect()
+}
+
+/// Accepts posted browser logs and forwards formatted lines to the sink.
+///
+/// # Arguments
+///
+/// * `state` - Shared relay receiver state.
+/// * `payload` - Posted browser log payload.
+///
+/// # Returns
+///
+/// [`StatusCode::NO_CONTENT`] after the payload has been accepted.
+pub async fn relay_log_handler(
+    State(state): State<RelayReceiverState>,
+    Json(payload): Json<RelayLogPayload>,
+) -> StatusCode {
+    let formatted = format_relay_line(&payload, state.verbose);
+
+    for line in split_formatted_lines(&formatted) {
+        (state.sink)(line);
+    }
+
+    StatusCode::NO_CONTENT
+}
+
+/// Builds an Axum router for receiving browser relay logs.
+///
+/// # Arguments
+///
+/// * `state` - Shared relay receiver state.
+///
+/// # Returns
+///
+/// A router that accepts `POST /` and `POST /_leptos/web-log`.
+pub fn relay_router(state: RelayReceiverState) -> Router {
+    Router::new()
+        .route("/", post(relay_log_handler))
+        .route(DEFAULT_WEB_LOG_RELAY_ENDPOINT, post(relay_log_handler))
+        .with_state(state)
+}
+
+fn parse_semantic_log_kind(target: Option<&str>) -> Option<SemanticLogKind> {
+    match target {
+        Some(MESSAGE_TARGET) => Some(SemanticLogKind::Message),
+        Some(SUCCESS_TARGET) => Some(SemanticLogKind::Success),
+        _ => None,
+    }
+}
+
+fn format_semantic_line(kind: SemanticLogKind, message: &str, verbose: bool) -> String {
+    let (color, hashtags) = match kind {
+        SemanticLogKind::Message => (ANSI_BLUE, "######"),
+        SemanticLogKind::Success => (ANSI_GREEN, "######"),
+    };
+
+    if verbose {
+        return format!("\n{color}{hashtags} {message} {hashtags}{ANSI_CLEAR}\n");
+    }
+
+    format!("{color}{message}{ANSI_CLEAR}")
+}
+
+fn format_non_verbose(level: WebLogLevel, message: &str) -> String {
+    match level {
+        WebLogLevel::Error => format!("{ANSI_RED}[ERROR] {message}{ANSI_CLEAR}"),
+        WebLogLevel::Warn => format!("{ANSI_YELLOW}[WARN] {message}{ANSI_CLEAR}"),
+        WebLogLevel::Info => message.to_string(),
+        WebLogLevel::Debug => format!("{ANSI_BLUE}[DEBUG] {message}{ANSI_CLEAR}"),
+        WebLogLevel::Trace => format!("{ANSI_MAGENTA}[TRACE] {message}{ANSI_CLEAR}"),
+    }
+}
+
+fn format_error_like(
+    title: &str,
+    color: &str,
+    file: &str,
+    line_number: &str,
+    message: &str,
+) -> String {
+    let hashtags = "######";
+    format!(
+        "\n{color}{hashtags} {title} {hashtags}{ANSI_CLEAR}\n{color}File: {file}{ANSI_CLEAR}\n{color}Line Number: {line_number}{ANSI_CLEAR}\n\n{color}{message}{ANSI_CLEAR}"
+    )
+}
+
+fn extract_after_src(path: &str) -> String {
+    let src_prefix = "src/";
+    if let Some(start_index) = path.find(src_prefix) {
+        return path[start_index + src_prefix.len()..].to_string();
+    }
+
+    path.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode, header},
+    };
+    use tower::ServiceExt;
+
+    use super::{
+        RelayReceiverState, WebLogLevel, extract_after_src, format_non_verbose, format_relay_line,
+        relay_router, split_formatted_lines,
+    };
+    use crate::relay::{DEFAULT_WEB_LOG_RELAY_ENDPOINT, RelayLogPayload};
+
+    #[test]
+    fn parse_level_defaults_to_info() {
+        assert_eq!(WebLogLevel::parse("wat"), WebLogLevel::Info);
+        assert_eq!(WebLogLevel::parse("warn"), WebLogLevel::Warn);
+    }
+
+    #[test]
+    fn extract_after_src_returns_relative_suffix() {
+        assert_eq!(
+            extract_after_src("/tmp/project/src/main.rs"),
+            "main.rs".to_string()
+        );
+    }
+
+    #[test]
+    fn non_verbose_error_uses_api_style_prefix() {
+        let formatted = format_non_verbose(WebLogLevel::Error, "boom");
+        assert!(formatted.contains("[ERROR] boom"));
+        assert!(formatted.contains("\u{1b}[31m"));
+    }
+
+    #[test]
+    fn verbose_debug_uses_banner_format() {
+        let payload = RelayLogPayload {
+            level: "debug".to_string(),
+            message: "test log".to_string(),
+            target: Some("app::module".to_string()),
+            file: Some("/tmp/project/src/app/mod.rs".to_string()),
+            line: Some(42),
+        };
+
+        let formatted = format_relay_line(&payload, true);
+        assert!(formatted.contains("###### Debug ######"));
+        assert!(formatted.contains("File: app/mod.rs"));
+        assert!(formatted.contains("Line Number: 42"));
+        assert!(formatted.contains("test log"));
+    }
+
+    #[test]
+    fn split_formatted_lines_preserves_blank_lines() {
+        let formatted = "\n\x1b[31m###### Error ######\x1b[0m\n\n\x1b[31mboom\x1b[0m\n";
+        let lines = split_formatted_lines(formatted);
+
+        assert_eq!(lines.len(), 5);
+        assert_eq!(lines[0], "");
+        assert!(lines[1].contains("###### Error ######"));
+        assert_eq!(lines[2], "");
+        assert!(lines[3].contains("boom"));
+        assert_eq!(lines[4], "");
+    }
+
+    #[test]
+    fn semantic_success_uses_api_style_formatting() {
+        let payload = RelayLogPayload {
+            level: "info".to_string(),
+            message: "Database connection established".to_string(),
+            target: Some("goggin_rs_logger::success".to_string()),
+            file: Some("/tmp/project/src/app/mod.rs".to_string()),
+            line: Some(42),
+        };
+
+        let verbose = format_relay_line(&payload, true);
+        assert!(verbose.contains("###### Database connection established ######"));
+        assert!(verbose.contains("\u{1b}[32m"));
+
+        let non_verbose = format_relay_line(&payload, false);
+        assert!(non_verbose.contains("Database connection established"));
+        assert!(non_verbose.contains("\u{1b}[32m"));
+    }
+
+    #[tokio::test]
+    async fn relay_router_posts_payload_to_sink() {
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let sink_received = Arc::clone(&received);
+        let state = RelayReceiverState::new(
+            Arc::new(move |line| {
+                sink_received
+                    .lock()
+                    .expect("received lines should not be poisoned")
+                    .push(line);
+            }),
+            false,
+        );
+        let app = relay_router(state);
+
+        let response = app
+            .clone()
+            .oneshot(relay_request(DEFAULT_WEB_LOG_RELAY_ENDPOINT))
+            .await
+            .expect("default endpoint request should route");
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let response = app
+            .oneshot(relay_request("/"))
+            .await
+            .expect("root endpoint request should route");
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let lines = received
+            .lock()
+            .expect("received lines should not be poisoned");
+        assert_eq!(
+            lines.as_slice(),
+            [
+                "\u{1b}[31m[ERROR] boom\u{1b}[0m",
+                "\u{1b}[31m[ERROR] boom\u{1b}[0m"
+            ]
+        );
+    }
+
+    fn relay_request(uri: &str) -> Request<Body> {
+        let payload = RelayLogPayload {
+            level: "error".to_string(),
+            message: "boom".to_string(),
+            target: Some("app::module".to_string()),
+            file: Some("/tmp/project/src/app/mod.rs".to_string()),
+            line: Some(42),
+        };
+        let body = serde_json::to_vec(&payload).expect("payload should serialize");
+
+        Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .expect("request should build")
+    }
+}


### PR DESCRIPTION
## Summary
- Bootstrap the `goggin-rs-logger` crate and port the native logger backend, level helpers, formatting, redaction, and semantic logging helpers from GigLog.
- Add optional `axum` support for HTTP request/response middleware and relay receiver APIs.
- Add optional `leptos` support for the WASM browser relay emitter and shared relay payload contract.
- Add crate-level docs, README examples, CI workflow, and v0.1.0 package metadata for release preparation.
- Apply review fixes for broader credential redaction, examples that use the crate's `info!` re-export, and AGENTS.md wording corrections.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo check --target wasm32-unknown-unknown --features leptos`
- `cargo doc --no-deps --all-features`
- `cargo publish --dry-run --allow-dirty` succeeded with only Cargo's expected dry-run upload warning

## Release Notes
- This PR prepares the crate for a future `v0.1.0` git tag.
- It does not create or push a release tag and does not publish to crates.io.